### PR TITLE
added linking to card on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
                     <h3>October 29th -  31st</h3>
 
                     <h3><a class="page-scroll" href="#venue">Min H. Kao Building<br>UTK</a></h3>
+                    <h3><a class="page-scroll" href="#hybrid-event-details">Hybrid Event Details</a></h3>
                     <br>
                     <ul class="list-inline banner-social-buttons">
                             <li>
@@ -689,17 +690,17 @@
                                 href="https://www.google.com/maps/place/Department+of+Electrical+Engineering+and+Computer+Science/@35.958735,-83.924121,18z/data=!4m5!3m4!1s0x0:0x5ae47667cdb72706!8m2!3d35.9586585!4d-83.9245267?hl=en-US">
                                 1520 Middle Dr, Knoxville, TN 37996.</a></p>
                 </div>
-                <div class="card">
+                <div class="card" id="hybrid-event-details">
                     <h4>Where do I park?</h4>
                     <p>Free parking is available in the <a target="_blank"
                                                            href="https://www.google.com/maps/place/11th+Street+Parking+Garage,+1101+Cumberland+Ave,+Knoxville,+TN+37916/@35.9597291,-83.9274756,17z/data=!3m1!4b1!4m5!3m4!1s0x885c17ddb7a7e377:0x5102d7d12e225a36!8m2!3d35.9597059!4d-83.9252861">11th
                         Street Parking Garage</a>, right across the street from Min Kao.</p>
+                    </div>
+                    <div class="card" >
+                        <h4>Hybrid Event Details</h4>
+                        <p>Due to the uncertainty of the development of COVID-19, we will be offering both in-person and virtual options for this year's event. For those attending in person, we will be implementing the Federal, State, and Local COVID-19 Guidelines at the time of the event to maintain the health and safety of the other participants. These guidelines include but are not limited to required masks at all times while within the premises and enforced social distancing. If you feel sick or have been recently exposed to someone who has COVID-19, we ask you to please attend the event virtually.</p>
+                    </div>
                 </div>
-                <div class="card">
-                    <h4>Hybrid Event Details</h4>
-                    <p>Due to the uncertainty of the development of COVID-19, we will be offering both in-person and virtual options for this year's event. For those attending in person, we will be implementing the Federal, State, and Local COVID-19 Guidelines at the time of the event to maintain the health and safety of the other participants. These guidelines include but are not limited to required masks at all times while within the premises and enforced social distancing. If you feel sick or have been recently exposed to someone who has COVID-19, we ask you to please attend the event virtually.</p>
-                </div>
-            </div>
         </div>
     </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -576,7 +576,7 @@
 
 <!--FAQ Section-->
 <section id="faq" class="container content-section text-center">
-    <div class="row">
+    <div class="row" id="hybrid-event-details">
         <div class="col-lg-8 col-lg-offset-2">
             <h2>Frequently Asked Questions</h2>
             <br>
@@ -633,6 +633,15 @@
                 </div>
             </div>
             <div class="col-md-6 faq-column">
+                <div class="card" >
+                    <h4>Hybrid Event Details</h4>
+                    <p>Due to the uncertainty of the development of COVID-19, we will be offering both in-person and virtual options for this year's event. For those attending in person, we will be implementing the Federal, State, and Local COVID-19 Guidelines at the time of the event to maintain the health and safety of the other participants. These guidelines include but are not limited to required masks at all times while within the premises and enforced social distancing. If you feel sick or have been recently exposed to someone who has COVID-19, we ask you to please attend the event virtually.</p>
+                </div>
+                <div class="card">
+                    <h4>Is there a code of conduct?</h4>
+                    <p>Yes, we abide by the <a href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf"
+                                               target="_blank">Major League Hacking Code of Conduct</a>.</p>
+                </div>
                 <div class="card">
                     <h4>Will you have a hardware lab?</h4>
                     <p>Yes! VolHacks is not just software! The Hardware Lab is an area where you can borrow hardware you
@@ -640,11 +649,6 @@
                         or send suggestions on what feel you would like to use. You can review a list of hardware lab 
                         <a target="_blank"
                                 href="https://hack.mlh.io/hardware/">here</a>.</p>
-                </div>
-                <div class="card">
-                    <h4>Is there a code of conduct?</h4>
-                    <p>Yes, we abide by the <a href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf"
-                                               target="_blank">Major League Hacking Code of Conduct</a>.</p>
                 </div>
                 <div class="card">
                     <h4>Do I need to stay the entire time?</h4>
@@ -690,15 +694,11 @@
                                 href="https://www.google.com/maps/place/Department+of+Electrical+Engineering+and+Computer+Science/@35.958735,-83.924121,18z/data=!4m5!3m4!1s0x0:0x5ae47667cdb72706!8m2!3d35.9586585!4d-83.9245267?hl=en-US">
                                 1520 Middle Dr, Knoxville, TN 37996.</a></p>
                 </div>
-                <div class="card" id="hybrid-event-details">
+                <div class="card">
                     <h4>Where do I park?</h4>
                     <p>Free parking is available in the <a target="_blank"
                                                            href="https://www.google.com/maps/place/11th+Street+Parking+Garage,+1101+Cumberland+Ave,+Knoxville,+TN+37916/@35.9597291,-83.9274756,17z/data=!3m1!4b1!4m5!3m4!1s0x885c17ddb7a7e377:0x5102d7d12e225a36!8m2!3d35.9597059!4d-83.9252861">11th
                         Street Parking Garage</a>, right across the street from Min Kao.</p>
-                    </div>
-                    <div class="card" >
-                        <h4>Hybrid Event Details</h4>
-                        <p>Due to the uncertainty of the development of COVID-19, we will be offering both in-person and virtual options for this year's event. For those attending in person, we will be implementing the Federal, State, and Local COVID-19 Guidelines at the time of the event to maintain the health and safety of the other participants. These guidelines include but are not limited to required masks at all times while within the premises and enforced social distancing. If you feel sick or have been recently exposed to someone who has COVID-19, we ask you to please attend the event virtually.</p>
                     </div>
                 </div>
         </div>


### PR DESCRIPTION
I had to link the "hybrid event details" text to the "park" card because if it added the id to hybrid event details card then it was scrolling too far.